### PR TITLE
Add initial server implementation

### DIFF
--- a/cmd/heimdall/main.go
+++ b/cmd/heimdall/main.go
@@ -1,5 +1,38 @@
 package main
 
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mattmeyers/level"
+	"github.com/ninth-realm/heimdall/http"
+)
+
 func main() {
-	println("Hello, World!")
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(1)
+	}
+}
+
+var (
+	flagPort int
+)
+
+func run() error {
+	initFlags()
+	return buildServer().ListenAndServe(fmt.Sprintf(":%d", flagPort))
+}
+
+func initFlags() {
+	flag.IntVar(&flagPort, "port", 8080, "port to run on")
+	flag.Parse()
+}
+
+func buildServer() *http.Server {
+	srv := http.NewServer()
+	srv.Logger, _ = level.NewBasicLogger(level.Info, nil)
+
+	return srv
 }

--- a/cmd/heimdall/main_test.go
+++ b/cmd/heimdall/main_test.go
@@ -1,9 +1,0 @@
-package main
-
-import "testing"
-
-func TestStuff(t *testing.T) {
-	if 1 == 2 {
-		t.Fatal("Math is broken")
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/ninth-realm/heimdall
 
 go 1.20
+
+require github.com/go-chi/chi/v5 v5.0.8
+
+require github.com/mattmeyers/level v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/mattmeyers/assert v0.2.0 h1:11l5I8oT2CykOdvKnC1VuZ2A1M1t4OSJmj/5xtxqlN8=
+github.com/mattmeyers/level v0.2.0 h1:WoRDRetHwYQMKjlryxTYGBW64jbdIhEY2C1v7uVMDsY=
+github.com/mattmeyers/level v0.2.0/go.mod h1:otFs6PrTh8FZKN2VKi6YsiPpoZfxgT4WFx4mfqp/e04=

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"net/http"
+)
+
+func (s *Server) handleIndex() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.respond(w, r, 200, "Hello, World!")
+	})
+}

--- a/http/handlers_test.go
+++ b/http/handlers_test.go
@@ -1,0 +1,17 @@
+package http
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_handleIndex_ReturnsCorrectStatus(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	NewServer().handleIndex()(w, r)
+
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+}

--- a/http/routes.go
+++ b/http/routes.go
@@ -1,0 +1,5 @@
+package http
+
+func (s *Server) loadRoutes() {
+	s.Router.Get("/", s.handleIndex())
+}

--- a/http/server.go
+++ b/http/server.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/mattmeyers/level"
+)
+
+type Server struct {
+	Logger level.Logger
+
+	Router chi.Router
+}
+
+// NewServer builds a new server object with the default middleware and router
+// already configured. This is the typical way that `Server`s should be created
+// to ensure they have everything needed to function.
+func NewServer() *Server {
+	r := chi.NewRouter()
+
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger)
+
+	s := &Server{Router: r}
+	s.loadRoutes()
+
+	return s
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.Router.ServeHTTP(w, r)
+}
+
+// ListenAndServe spins up the server to listen on the provided address. The
+// allowed addresses follow the same rules as `http.ListenAndServe`.
+func (s *Server) ListenAndServe(addr string) error {
+	if s.Logger == nil {
+		s.Logger, _ = level.NewBasicLogger(level.Info, nil)
+	}
+
+	s.Logger.Info("Server listening on %s", addr)
+	return http.ListenAndServe(addr, s)
+}
+
+// The max size in bytes of a request body. 5 mB should be plenty.
+const requestBodyLimit = 5_242_880
+
+// Reads a request body into the provided destination. It is expected that the
+// `dst` parameter is a pointer and that the request body is JSON.
+func (s *Server) decode(r *http.Request, dst any) error {
+	return json.NewDecoder(io.LimitReader(r.Body, requestBodyLimit)).Decode(dst)
+}
+
+// Writes a response to the client. All responses are written in an envelope with
+// the provided data under the `response` key. At this point, all responses are
+// encoded as JSON.
+//
+// This method does not return any errors. If an error occurs during the encoding
+// process, the error is logged and an internal server error is returned to the
+// client.
+func (s *Server) respond(w http.ResponseWriter, r *http.Request, status int, data any) {
+	type envelope struct {
+		Response any `json:"response"`
+	}
+
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(envelope{Response: data})
+	if err != nil {
+		s.respondWithError(w, r, http.StatusInternalServerError, err)
+	}
+}
+
+// Writes an error response to the client. If the provided status code is a 5xx
+// code, then the error is logged, and the appropriate status text is used in
+// the response. We do not want to leak any internal details to the client.
+func (s *Server) respondWithError(w http.ResponseWriter, r *http.Request, status int, data error) {
+	type envelope struct {
+		Code  int    `json:"code"`
+		Error string `json:"error"`
+	}
+
+	if status >= 500 {
+		s.logError(r, data)
+		data = errors.New(http.StatusText(status))
+	}
+
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(envelope{Code: status, Error: data.Error()})
+	if err != nil {
+		// If we get here, something is seriously wrong. Log and move on.
+		s.logError(r, data)
+	}
+
+}
+
+func (s *Server) logError(r *http.Request, err error) {
+	s.Logger.Error("%s: %v", r.Context().Value(middleware.RequestIDKey), err)
+}


### PR DESCRIPTION
## Summary

This PR adds the initial HTTP server infrastructure. At this point, the server only has a few basic utilities. Adding routes off of the server should be simple enough.

## Testing

1. Ensure CI passes.
2. Spin up the API with `go run cmd/heimdall/main.go` and hit the dummy endpoint with `curl http://localhost:8080`. Ensure a 200 is returned and the request is logged.

closes #1 